### PR TITLE
use path.resolve instead of path.join

### DIFF
--- a/paths.js
+++ b/paths.js
@@ -2,4 +2,4 @@ var path = require('path');
 
 exports.CONFIG = process.env.ENV_VAR_CONFIG_FILE || 'env.json';
 
-exports.get = (fileName) => path.join(process.cwd(), fileName);
+exports.get = (fileName) => path.resolve(process.cwd(), fileName);


### PR DESCRIPTION
Allows for use of an absolute URL in ENV_VAR_CONFIG_FILE